### PR TITLE
Fix invalid input name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,9 @@ inputs:
   days-before-close:
     required: true
     description: Days before an issue is closed after the stale label has been added to it
-  close-comment:
+  close-message:
     required: true
-    description: Comment which will be added to issues when closing
+    description: Message which will be added to issues when closing
   dry-run:
     description: Run the action without effectively closing stale issues
     default: 'false'


### PR DESCRIPTION
Update `close-comment` to `close-message`

![image](https://github.com/user-attachments/assets/1fcbd379-eaee-4356-9f7c-120025987a92)

Ref action run: https://github.com/directus/directus/actions/runs/12488260717/job/34850423773